### PR TITLE
Fix hopper minecarts being able to pull from locked chests

### DIFF
--- a/src/org/yi/acru/bukkit/Lockette/Lockette.java
+++ b/src/org/yi/acru/bukkit/Lockette/Lockette.java
@@ -40,6 +40,7 @@ public class Lockette extends PluginCore{
 	private static boolean					registered = false;
 	private final LocketteBlockListener		blockListener = new LocketteBlockListener(this);
 	private final LocketteEntityListener	entityListener = new LocketteEntityListener(this);
+	private final LocketteInventoryListener	inventoryListener = new LocketteInventoryListener(this);
 	private final LockettePlayerListener	playerListener = new LockettePlayerListener(this);
 	private final LockettePrefixListener	prefixListener = new LockettePrefixListener(this);
 	private final LocketteWorldListener		worldListener = new LocketteWorldListener(this);
@@ -127,6 +128,7 @@ public class Lockette extends PluginCore{
 		if(!registered){
 			blockListener.registerEvents();
 			entityListener.registerEvents();
+			inventoryListener.registerEvents();
 			playerListener.registerEvents();
 			prefixListener.registerEvents();
 			worldListener.registerEvents();
@@ -395,7 +397,7 @@ public class Lockette extends PluginCore{
 		// Load in the alternate sign strings.
 		
 		altPrivate = strings.getString("alternate-private-tag");
-		if((altPrivate == null) || altPrivate.isEmpty() || (original && altPrivate.equals("Privé"))){
+		if((altPrivate == null) || altPrivate.isEmpty() || (original && altPrivate.equals("Privï¿½"))){
 			altPrivate = "Private";
 			strings.set("alternate-private-tag", altPrivate);
 		}
@@ -418,7 +420,7 @@ public class Lockette extends PluginCore{
 		altEveryone = "["+altEveryone+"]";
 		
 		altOperators = strings.getString("alternate-operators-tag");
-		if((altOperators == null) || altOperators.isEmpty() || (original && altOperators.equals("Opérateurs"))){
+		if((altOperators == null) || altOperators.isEmpty() || (original && altOperators.equals("Opï¿½rateurs"))){
 			altOperators = "Operators";
 			strings.set("alternate-operators-tag", altOperators);
 			stringChanged = true;

--- a/src/org/yi/acru/bukkit/Lockette/LocketteInventoryListener.java
+++ b/src/org/yi/acru/bukkit/Lockette/LocketteInventoryListener.java
@@ -1,6 +1,7 @@
 package org.yi.acru.bukkit.Lockette;
 
 import org.bukkit.block.BlockState;
+import org.bukkit.block.DoubleChest;
 
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -31,13 +32,21 @@ public class LocketteInventoryListener implements Listener {
 	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onInventoryMoveItem(InventoryMoveItemEvent event) {
 		InventoryHolder sourceHolder = event.getSource().getHolder();
+		if (sourceHolder instanceof DoubleChest) {
+			// checking one side is sufficient
+			sourceHolder = ((DoubleChest)sourceHolder).getLeftSide();
+		}
 		if (sourceHolder instanceof BlockState) {
 			if (Lockette.isProtected( ((BlockState)sourceHolder).getBlock() )) {
 				event.setCancelled(true);
 				return;
 			}
 		}
+
 		InventoryHolder destHolder = event.getDestination().getHolder();
+		if (destHolder instanceof DoubleChest) {
+			destHolder = ((DoubleChest)destHolder).getLeftSide();
+		}
 		if (destHolder instanceof BlockState) {
 			if (Lockette.isProtected( ((BlockState)destHolder).getBlock() )) {
 				event.setCancelled(true);

--- a/src/org/yi/acru/bukkit/Lockette/LocketteInventoryListener.java
+++ b/src/org/yi/acru/bukkit/Lockette/LocketteInventoryListener.java
@@ -1,0 +1,48 @@
+package org.yi.acru.bukkit.Lockette;
+
+import org.bukkit.block.BlockState;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+
+import org.bukkit.inventory.InventoryHolder;
+
+import org.bukkit.plugin.PluginManager;
+
+public class LocketteInventoryListener implements Listener {
+	private static Lockette plugin;
+
+	public LocketteInventoryListener(Lockette instance) {
+		plugin = instance;
+	}
+
+	protected void registerEvents() {
+
+		PluginManager pm = plugin.getServer().getPluginManager();
+
+		pm.registerEvents(this, plugin);
+	}
+
+	//********************************************************************************************************************
+	// Start of event section
+
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onInventoryMoveItem(InventoryMoveItemEvent event) {
+		InventoryHolder sourceHolder = event.getSource().getHolder();
+		if (sourceHolder instanceof BlockState) {
+			if (Lockette.isProtected( ((BlockState)sourceHolder).getBlock() )) {
+				event.setCancelled(true);
+				return;
+			}
+		}
+		InventoryHolder destHolder = event.getDestination().getHolder();
+		if (destHolder instanceof BlockState) {
+			if (Lockette.isProtected( ((BlockState)destHolder).getBlock() )) {
+				event.setCancelled(true);
+				return;
+			}
+		}
+	}
+}


### PR DESCRIPTION
I wrote this before I saw #6 but that version has an unchecked cast that I think will cause a crash when a hopper block pulls from a chest minecart.
