### PR TITLE
Fix bug with Trapped Chest support

### DIFF
--- a/src/org/yi/acru/bukkit/Lockette/LocketteBlockListener.java
+++ b/src/org/yi/acru/bukkit/Lockette/LocketteBlockListener.java
@@ -467,7 +467,7 @@ public class LocketteBlockListener implements Listener {
 
 			if (plugin.hasPermission(block.getWorld(), player, "lockette.create.all"))
 				create = true;
-			else if (type == Material.CHEST.getId()) {
+			else if (type == Material.CHEST.getId() || type == Material.TRAPPED_CHEST.getId()) {
 				if (plugin.hasPermission(block.getWorld(), player, "lockette.user.create.chest"))
 					create = true;
 			} else if ((type == Material.FURNACE.getId()) || (type == Material.BURNING_FURNACE.getId())) {


### PR DESCRIPTION
There is a bug with trapped chests. Non-op players can't lock trapped chest when direct right clicking in the trapped chest with a sign (it always said "no permission to claim container" even if they have "lockette.create.*"). However, it's works when manually placing a sign behind the chest (and manually type "[Private] ...").

I think this little change will fix the problem, I can't test because I can't find some of the required librairies to compile PluginCore.

(sorry for my english which is not my native language)
